### PR TITLE
Move tensorflow deps to optional [tflite] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,7 @@ dependencies = [
   "onnx",
   "onnxsim-prebuilt ; platform_system == 'Linux'",
   "onnx-graphsurgeon ; platform_system == 'Linux'",
-  "tensorflow",
-  "onnx2tf",
-  "tf-keras",
   "psutil",
-  "h5py",
-  "ml_dtypes",
 ]
 
 [project.urls]
@@ -69,6 +64,13 @@ vino = [
 ]
 litert = [
   'ai-edge-litert',
+]
+tflite = [
+  "tensorflow",
+  "onnx2tf",
+  "tf-keras",
+  "h5py",
+  "ml_dtypes",
 ]
 
 


### PR DESCRIPTION
## Summary

- Moves `tensorflow`, `onnx2tf`, `tf-keras`, `h5py`, and `ml_dtypes` from core `dependencies` to a new `[tflite]` optional extra
- These packages are only used by `predict_tflite.py` and are unnecessary for consumers using `darknet2any[tensorrt]`, `darknet2any[rocm]`, etc.

## Problem

When installing `darknet2any[tensorrt]`, pip pulls in tensorflow and onnx2tf as mandatory dependencies. Because onnx2tf is unpinned, the resolver backtracks through 30+ versions trying to find one compatible with the rest of the dependency tree. This adds minutes to every install and downloads ~1.5GB of packages that are never imported.

## Change

Users who need TFLite conversion can install with `pip install darknet2any[tflite]` (or `darknet2any[tensorrt,tflite]`). Everyone else gets a faster, leaner install.

No code changes - only `pyproject.toml` dependency classification.