### PR TITLE
Pin TensorRT below 11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ Issues = "https://github.com/jredmondson/darknet2any/issues"
 
 [project.optional-dependencies]
 tensorrt = [
-  "tensorrt",
+  "tensorrt<11",
   "pycuda",
   "onnxruntime-gpu",
 ]

--- a/requirements-tensorrt.txt
+++ b/requirements-tensorrt.txt
@@ -15,7 +15,7 @@ onnxsim-prebuilt
 onnx-graphsurgeon
 pycuda
 tensorflow
-tensorrt
+tensorrt<11
 onnx2tf
 tf-keras
 psutil

--- a/requirements-tensortrt-windows.txt
+++ b/requirements-tensortrt-windows.txt
@@ -15,7 +15,7 @@ onnxsim-prebuilt
 onnx-graphsurgeon
 pycuda
 tensorflow
-tensorrt
+tensorrt<11
 onnx2tf
 tf-keras
 psutil


### PR DESCRIPTION
Pins TensorRT installs below 11 until onnx2trt supports the TensorRT 11 API.